### PR TITLE
Use setuptools instead

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from distutils.core import setup
+from setuptools import setup
 
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
The setup.py uses fields that are only defined for setuptools

```
/usr/local/Cellar/python/3.6.5_1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'long_description_content_type'
  warnings.warn(msg)
/usr/local/Cellar/python/3.6.5_1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'requires_python'
  warnings.warn(msg)
/usr/local/Cellar/python/3.6.5_1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'install_requires'
```

`setuptools` works better and is more feature rich and is a fair dependency in modern day python packaging. 