### PR TITLE
Python3.8 support

### DIFF
--- a/aioify/__init__.py
+++ b/aioify/__init__.py
@@ -27,9 +27,9 @@ def wrap(func):
     async def coroutine_function_run(*args, **kwargs):
         return await func(*args, **kwargs)
 
-    if inspect.iscoroutine(object=func):
+    if inspect.iscoroutine(func):
         result = coroutine_run
-    elif inspect.iscoroutinefunction(object=func):
+    elif inspect.iscoroutinefunction(func):
         result = coroutine_function_run
     else:
         result = run


### PR DESCRIPTION
Due to a renaming in inspect.py in Python3.8, aioify breaks. This patch removes the explicit passing of object=, to not mess with either versions. 

Python3.7: 
```py
def iscoroutinefunction(object):
``` 
Python3.8:
```py
def iscoroutinefunction(obj):
```